### PR TITLE
Smaller console size for 1366x768 host displays

### DIFF
--- a/cmdline
+++ b/cmdline
@@ -1,1 +1,1 @@
-console=tty0 console=ttyS0,115200n8 quiet init=/usr/bin/initra initcall_debug tsc=reliable no_timer_check noreplace-smp kvm-intel.nested=1 rootfstype=ext4,btrfs,xfs intel_iommu=igfx_off cryptomgr.notests rcupdate.rcu_expedited=1 ipv6.disable=1 rw 
+console=tty0 console=ttyS0,115200n8 quiet init=/usr/bin/initra initcall_debug tsc=reliable no_timer_check noreplace-smp kvm-intel.nested=1 rootfstype=ext4,btrfs,xfs intel_iommu=igfx_off cryptomgr.notests rcupdate.rcu_expedited=1 ipv6.disable=1 video=hyperv_fb:1024x576 rw


### PR DESCRIPTION
The default console window size set by hyperv_fb kernel module is too big for common low-end laptop display sizes such as 1366x768, which makes experimentation with ClearLinux on Windows 10 Hyper-V hard. And 1024x576 still provides with enough room for recovery tasks on larger displays and it doesn't look too small on 1920x1050, given that it's only needed for situations where SSH is not available. The screen size can be changed later at runtime with fbset command (which is not yet available in ClearLinux packages though).

If approved, this should be ported to Hyper-V LTS as well. Also note that not all XXXXxYYY sizes work.