### PR TITLE
Added recommended I/O scheduler

### DIFF
--- a/cmdline
+++ b/cmdline
@@ -1,1 +1,1 @@
-console=tty0 console=ttyS0,115200n8 video=hyperv_fb:1024x576 quiet init=/usr/bin/initra initcall_debug tsc=reliable no_timer_check noreplace-smp kvm-intel.nested=1 rootfstype=ext4,btrfs,xfs intel_iommu=igfx_off cryptomgr.notests rcupdate.rcu_expedited=1 ipv6.disable=1 rw 
+console=tty0 console=ttyS0,115200n8 video=hyperv_fb:1024x576 quiet elevator=noop init=/usr/bin/initra initcall_debug tsc=reliable no_timer_check noreplace-smp kvm-intel.nested=1 rootfstype=ext4,btrfs,xfs intel_iommu=igfx_off cryptomgr.notests rcupdate.rcu_expedited=1 ipv6.disable=1 rw 


### PR DESCRIPTION
Added kernel parameter for Microsoft's recommended I/O scheduler for Linux VMs (https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/best-practices-for-running-linux-on-hyper-v#use-io-scheduler-noop-for-better-disk-io-performance).